### PR TITLE
Add support for partial writes and no sync options in InfluxDB v3 node

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ Writes data points to InfluxDB v3.
 - **Name**: Optional node name
 - **Measurement**: Default measurement name (can be overridden by `msg.measurement`)
 - **Database**: Optional database override (uses connection default if not set)
+- **Partial writes**: Accept the valid lines of a batch even if other lines are rejected (InfluxDB 3 Core/Enterprise only)
+- **No sync**: Respond without waiting for WAL persistence — faster writes without durability confirmation (InfluxDB 3 Core/Enterprise only)
+
+#### Partial Writes
+
+By default a batch write is all-or-nothing: one invalid line causes InfluxDB to reject the entire batch. With **Partial writes** enabled, InfluxDB writes the valid lines and reports the rejected ones. The node then:
+
+- shows a yellow `partial write` status instead of an error
+- logs a warning listing each rejected line and the reason
+- forwards the message with the details attached as `msg.partialWriteErrors`, an array of `{ lineNumber, errorMessage, originalLine }` objects
+
+Enabling **Partial writes** or **No sync** routes the write through the InfluxDB v3 API endpoint, which is only available on InfluxDB 3 Core and Enterprise. On other deployments (Cloud Serverless/Dedicated, Clustered) leave both options disabled — writes there use the v2-compatible endpoint, where these options are not supported and would cause writes to fail. When **No sync** is enabled without **Partial writes**, the node keeps the all-or-nothing write semantics.
 
 ## Usage
 

--- a/__tests__/influxdb3.test.js
+++ b/__tests__/influxdb3.test.js
@@ -57,9 +57,18 @@ jest.mock('@influxdata/influxdb3-client', () => {
     }
   }
 
+  class MockPartialWriteError extends Error {
+    constructor(message, lineErrors) {
+      super(message);
+      this.name = 'PartialWriteError';
+      this.lineErrors = lineErrors;
+    }
+  }
+
   return {
     InfluxDBClient: MockInfluxDBClient,
     Point: MockPoint,
+    PartialWriteError: MockPartialWriteError,
     __getLastClientOptions: () => mockLastClientOptions,
     __getLastClientInstance: () => mockLastClientInstance,
     __getLastPoint: () => mockLastPoint
@@ -313,7 +322,7 @@ describe('InfluxDB v3 write node', () => {
 });
 
 // Helper to create a write node for addFieldToPoint / buildLineProtocol tests
-function createWriteNode() {
+function createWriteNode(writeConfig) {
   const { RED, influxModule } = setup();
   const ConfigCtor = RED._types['influxdb3-config'];
   const WriteCtor = RED._types['influxdb3-write'];
@@ -328,7 +337,8 @@ function createWriteNode() {
   const writeNode = new WriteCtor({
     influxdb: configNode,
     measurement: 'test_measurement',
-    database: ''
+    database: '',
+    ...writeConfig
   });
 
   return { RED, influxModule, configNode, writeNode };
@@ -1153,6 +1163,146 @@ describe('write node – client.write failure', () => {
     expect(statusArg.text.endsWith('...')).toBe(true);
     // done still receives the full, untruncated error
     expect(done.mock.calls[0][0].message).toBe(longMessage);
+  });
+});
+
+describe('write node – partial writes and noSync options', () => {
+  test('passes no write options by default (V2 endpoint)', async () => {
+    const { influxModule, writeNode } = createWriteNode();
+    const msg = { measurement: 'sensor', payload: { fields: { value: 1 } } };
+    const send = jest.fn();
+    const done = jest.fn();
+    await writeNode._handlers.input(msg, send, done);
+
+    const client = influxModule.__getLastClientInstance();
+    expect(client.write).toHaveBeenCalledWith(expect.any(String), 'metrics');
+  });
+
+  test('allowPartialWrites selects the V3 endpoint', async () => {
+    const { influxModule, writeNode } = createWriteNode({ allowPartialWrites: true });
+    const msg = { measurement: 'sensor', payload: { fields: { value: 1 } } };
+    const send = jest.fn();
+    const done = jest.fn();
+    await writeNode._handlers.input(msg, send, done);
+
+    const client = influxModule.__getLastClientInstance();
+    expect(client.write).toHaveBeenCalledWith(
+      expect.any(String),
+      'metrics',
+      undefined,
+      { useV2Api: false }
+    );
+    expect(done.mock.calls[0][0]).toBeUndefined();
+  });
+
+  test('noSync alone selects the V3 endpoint but keeps all-or-nothing semantics', async () => {
+    const { influxModule, writeNode } = createWriteNode({ noSync: true });
+    const msg = { measurement: 'sensor', payload: { fields: { value: 1 } } };
+    const send = jest.fn();
+    const done = jest.fn();
+    await writeNode._handlers.input(msg, send, done);
+
+    const client = influxModule.__getLastClientInstance();
+    expect(client.write).toHaveBeenCalledWith(
+      expect.any(String),
+      'metrics',
+      undefined,
+      { useV2Api: false, noSync: true, acceptPartial: false }
+    );
+  });
+
+  test('noSync with allowPartialWrites leaves acceptPartial at its default', async () => {
+    const { influxModule, writeNode } = createWriteNode({
+      allowPartialWrites: true,
+      noSync: true
+    });
+    const msg = { measurement: 'sensor', payload: { fields: { value: 1 } } };
+    const send = jest.fn();
+    const done = jest.fn();
+    await writeNode._handlers.input(msg, send, done);
+
+    const client = influxModule.__getLastClientInstance();
+    expect(client.write).toHaveBeenCalledWith(
+      expect.any(String),
+      'metrics',
+      undefined,
+      { useV2Api: false, noSync: true }
+    );
+  });
+
+  test('partial write is treated as success with warning, yellow status and lineErrors on msg', async () => {
+    const { influxModule, configNode, writeNode } = createWriteNode({ allowPartialWrites: true });
+    const { PartialWriteError } = influxModule;
+
+    const lineErrors = [
+      { lineNumber: 2, errorMessage: 'invalid field value', originalLine: 'cpu value=oops' }
+    ];
+    const client = configNode.getClient();
+    client.write = jest.fn().mockRejectedValue(
+      new PartialWriteError('partial write of line protocol occurred', lineErrors)
+    );
+
+    const msg = { measurement: 'sensor', payload: { fields: { value: 1 } } };
+    const send = jest.fn();
+    const done = jest.fn();
+    await writeNode._handlers.input(msg, send, done);
+
+    // Treated as (partial) success: message forwarded, done without error
+    expect(send).toHaveBeenCalledWith(msg);
+    expect(done).toHaveBeenCalled();
+    expect(done.mock.calls[0][0]).toBeUndefined();
+    expect(msg.partialWriteErrors).toEqual(lineErrors);
+    expect(writeNode.warn).toHaveBeenCalledWith(
+      expect.stringContaining('InfluxDB rejected 1 line(s)')
+    );
+    expect(writeNode.warn).toHaveBeenCalledWith(
+      expect.stringContaining('line 2: invalid field value')
+    );
+    expect(writeNode.status).toHaveBeenCalledWith(
+      expect.objectContaining({ fill: 'yellow', text: 'partial write: 1 line(s) rejected' })
+    );
+  });
+
+  test('full batch rejection (acceptPartial=false) is still an error', async () => {
+    const { influxModule, configNode, writeNode } = createWriteNode({ noSync: true });
+    const { PartialWriteError } = influxModule;
+
+    const client = configNode.getClient();
+    client.write = jest.fn().mockRejectedValue(
+      new PartialWriteError('parsing failed for write_lp endpoint', [
+        { lineNumber: 1, errorMessage: 'invalid field value', originalLine: 'cpu value=oops' }
+      ])
+    );
+
+    const msg = { measurement: 'sensor', payload: { fields: { value: 1 } } };
+    const send = jest.fn();
+    const done = jest.fn();
+    await writeNode._handlers.input(msg, send, done);
+
+    expect(send).not.toHaveBeenCalled();
+    expect(done).toHaveBeenCalledWith(expect.any(Error));
+    expect(writeNode.status).toHaveBeenCalledWith(
+      expect.objectContaining({ fill: 'red' })
+    );
+  });
+
+  test('PartialWriteError is an ordinary error when partial writes are not enabled', async () => {
+    const { influxModule, configNode, writeNode } = createWriteNode();
+    const { PartialWriteError } = influxModule;
+
+    const client = configNode.getClient();
+    client.write = jest.fn().mockRejectedValue(
+      new PartialWriteError('partial write of line protocol occurred', [])
+    );
+
+    const msg = { measurement: 'sensor', payload: { fields: { value: 1 } } };
+    const send = jest.fn();
+    const done = jest.fn();
+    await writeNode._handlers.input(msg, send, done);
+
+    expect(send).not.toHaveBeenCalled();
+    expect(done).toHaveBeenCalledWith(expect.any(Error));
+    expect(msg.partialWriteErrors).toBeUndefined();
   });
 });
 

--- a/influxdb3.html
+++ b/influxdb3.html
@@ -86,7 +86,9 @@
             influxdb: { type: 'influxdb3-config', required: true },
             name: { value: '' },
             measurement: { value: '' },
-            database: { value: '' }
+            database: { value: '' },
+            allowPartialWrites: { value: false },
+            noSync: { value: false }
         },
         inputs: 1,
         outputs: 1,
@@ -117,6 +119,16 @@
         <label for="node-input-database"><i class="fa fa-database"></i> Database</label>
         <input type="text" id="node-input-database" placeholder="Override default database (optional)">
     </div>
+    <div class="form-row">
+        <label for="node-input-allowPartialWrites"><i class="fa fa-tasks"></i> Partial writes</label>
+        <input type="checkbox" id="node-input-allowPartialWrites" style="width:auto;">
+        <span>Allow partial writes (InfluxDB 3 Core/Enterprise only)</span>
+    </div>
+    <div class="form-row">
+        <label for="node-input-noSync"><i class="fa fa-bolt"></i> No sync</label>
+        <input type="checkbox" id="node-input-noSync" style="width:auto;">
+        <span>Don't wait for WAL persistence (InfluxDB 3 Core/Enterprise only)</span>
+    </div>
 </script>
 
 <script type="text/html" data-help-name="influxdb3-write">
@@ -144,6 +156,10 @@
     <dl class="message-properties">
         <dt>payload <span class="property-type">object</span></dt>
         <dd>The original payload is passed through</dd>
+        <dt class="optional">partialWriteErrors <span class="property-type">array</span></dt>
+        <dd>Only set when a partial write occurred (see <b>Partial writes</b> below).
+            An array of <code>{ lineNumber, errorMessage, originalLine }</code> objects
+            describing the lines InfluxDB rejected</dd>
     </dl>
 
     <h3>Details</h3>
@@ -213,7 +229,25 @@
         <dd>The measurement name to use. Can be overridden by <code>msg.measurement</code></dd>
         <dt>Database</dt>
         <dd>Optional database override. If not set, uses the database from the connection config</dd>
+        <dt>Partial writes</dt>
+        <dd>When enabled, InfluxDB accepts the valid lines of a batch even if other lines
+            are rejected (InfluxDB 3 Core/Enterprise only)</dd>
+        <dt>No sync</dt>
+        <dd>When enabled, InfluxDB responds without waiting for WAL persistence — faster
+            writes but no durability confirmation (InfluxDB 3 Core/Enterprise only)</dd>
     </dl>
+
+    <h3>Partial writes</h3>
+    <p>By default a batch write is all-or-nothing: one invalid line causes InfluxDB to
+    reject the entire batch. With <b>Partial writes</b> enabled, the valid lines are
+    written and the rejected lines are reported: the node shows a yellow
+    <i>partial write</i> status, logs a warning with the per-line errors, and forwards
+    the message with the details in <code>msg.partialWriteErrors</code>.</p>
+    <p>Enabling <b>Partial writes</b> or <b>No sync</b> sends the write through the
+    InfluxDB v3 API endpoint, which is only available on InfluxDB 3 Core and
+    Enterprise. On other deployments (Cloud Serverless/Dedicated, Clustered) leave
+    both options disabled — writes there use the v2-compatible endpoint, where these
+    options are not supported.</p>
 
     <h3>Examples</h3>
     <h4>Example 1: Simple temperature reading</h4>

--- a/influxdb3.js
+++ b/influxdb3.js
@@ -12,7 +12,7 @@ module.exports = function(RED) {
     //   Point.setTag(name, value)
     //   Point.setTimestamp(date)
     //   Point.toLineProtocol()
-    const { InfluxDBClient, Point } = require('@influxdata/influxdb3-client');
+    const { InfluxDBClient, Point, PartialWriteError } = require('@influxdata/influxdb3-client');
     const fs = require('fs');
     const { validateLineProtocol } = require('./lib/line-protocol');
 
@@ -155,6 +155,10 @@ module.exports = function(RED) {
         this.influxdb = RED.nodes.getNode(config.influxdb);
         this.measurement = config.measurement;
         this.database = config.database;
+        /** @type {boolean} */
+        this.allowPartialWrites = config.allowPartialWrites === true;
+        /** @type {boolean} */
+        this.noSync = config.noSync === true;
 
         const node = this;
         let statusTimeout = null;
@@ -516,8 +520,29 @@ module.exports = function(RED) {
                     );
                 }
 
+                // Both acceptPartial and noSync exist only on the V3 API endpoint,
+                // so opting into either selects it. With neither enabled, no write
+                // options are passed and the client default (V2 endpoint) is used,
+                // preserving previous behaviour.
+                let writeOptions = null;
+                if (node.allowPartialWrites || node.noSync) {
+                    writeOptions = { useV2Api: false };
+                    if (node.noSync) {
+                        writeOptions.noSync = true;
+                    }
+                    if (!node.allowPartialWrites) {
+                        // noSync without partial writes: keep the all-or-nothing
+                        // semantics the V2 endpoint would have provided.
+                        writeOptions.acceptPartial = false;
+                    }
+                }
+
                 // Write to InfluxDB
-                await client.write(lineProtocol, targetDatabase);
+                if (writeOptions) {
+                    await client.write(lineProtocol, targetDatabase, undefined, writeOptions);
+                } else {
+                    await client.write(lineProtocol, targetDatabase);
+                }
 
                 setStatus({ fill: 'green', shape: 'dot', text: 'written' }, 3000);
 
@@ -525,6 +550,33 @@ module.exports = function(RED) {
                 done();
 
             } catch (error) {
+                // The client raises PartialWriteError both when the server accepted
+                // the valid lines (partial write occurred) and when it rejected the
+                // whole batch (acceptPartial=false). Only the former is a partial
+                // success; the server signals it with this specific error text.
+                if (node.allowPartialWrites &&
+                    error instanceof PartialWriteError &&
+                    typeof error.message === 'string' &&
+                    error.message.toLowerCase().includes('partial write')) {
+                    const lineErrors = error.lineErrors || [];
+                    const detail = lineErrors
+                        .map((le) => `line ${le.lineNumber}: ${le.errorMessage}`)
+                        .join('; ');
+                    node.warn(
+                        `Partial write: InfluxDB rejected ${lineErrors.length} line(s), ` +
+                        `the remaining lines were written. ${detail}`
+                    );
+                    msg.partialWriteErrors = lineErrors;
+                    setStatus({
+                        fill: 'yellow',
+                        shape: 'dot',
+                        text: `partial write: ${lineErrors.length} line(s) rejected`
+                    });
+                    send(msg);
+                    done();
+                    return;
+                }
+
                 const shortMsg = error.message
                     ? (error.message.length > 80 ? error.message.substring(0, 80) + '...' : error.message)
                     : 'unknown error';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "node-red-contrib-influxdb3",
-  "version": "1.0.6",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-influxdb3",
-      "version": "1.0.6",
+      "version": "1.0.9",
       "license": "MIT",
       "dependencies": {
-        "@influxdata/influxdb3-client": "^2.2.0"
+        "@influxdata/influxdb3-client": "^2.3.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -18,7 +18,7 @@
         "jest": "^30.3.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -719,9 +719,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.0.tgz",
-      "integrity": "sha512-N8Jx6PaYzcTRNzirReJCtADVoq4z7+1KQ4E70jTg/koQiMoUSN1kbNjPOqpPbhMFhfU1/l7ixspPl8dNY+FoUg==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
@@ -816,9 +816,9 @@
       }
     },
     "node_modules/@influxdata/influxdb3-client": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@influxdata/influxdb3-client/-/influxdb3-client-2.2.0.tgz",
-      "integrity": "sha512-kI2pDsIGsJ7ziIOM4gY/xBgWuCaDfPusiQbRRRBv9v20bVjp0RflV280K0JyjGpy/gctnVFSZ4EygLzySPllvg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@influxdata/influxdb3-client/-/influxdb3-client-2.3.0.tgz",
+      "integrity": "sha512-UtNYk6ZRP5HQ3ETtFvEmPUH5QLorwO9o2iabeYhjKB9ee7cgH4Q5O8YvdZdrG04FyFbPijIlZ1uoV9gpNMD5/g==",
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.9.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-influxdb3",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "Node-RED nodes for InfluxDB v3 integration",
   "main": "influxdb3.js",
   "files": [
@@ -42,7 +42,7 @@
     }
   },
   "dependencies": {
-    "@influxdata/influxdb3-client": "^2.2.0"
+    "@influxdata/influxdb3-client": "^2.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
- Updated README.md to document new features: partial writes and no sync.
- Enhanced influxdb3.js to handle partial writes and no sync configurations.
- Added corresponding tests for partial writes and no sync functionality.
- Updated influxdb3.html to include UI elements for new options.
- Bumped version to 1.1.0 and updated dependencies in package.json and package-lock.json.