### PR TITLE
Release v1.1.1: publish relaxed Node engine requirement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-influxdb3",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-influxdb3",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@influxdata/influxdb3-client": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-influxdb3",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Node-RED nodes for InfluxDB v3 integration",
   "main": "influxdb3.js",
   "files": [


### PR DESCRIPTION
The published 1.1.0 declares `engines.node: ">=24.0.0"`. Commit 28edf70 relaxed that to ">=22.9.0" but did not bump the version, so npm has continued to serve the stricter range and Node 22 users are refused the package by the Node-RED palette manager, which installs with `--engine-strict`.

No code changes; this bump exists solely to get the corrected engines field onto npm.